### PR TITLE
Fix canPhoneCreateMediaRecorder for Android

### DIFF
--- a/android/src/main/java/com/tchvu3/capvoicerecorder/CustomMediaRecorder.java
+++ b/android/src/main/java/com/tchvu3/capvoicerecorder/CustomMediaRecorder.java
@@ -60,7 +60,7 @@ public class CustomMediaRecorder {
             tempMediaRecorder.stopRecording();
             return true;
         } catch (Exception exp) {
-            return exp.getMessage().startsWith("stop failed");
+            return exp.getMessage() != null ? exp.getMessage().startsWith("stop failed") : true;
         } finally {
             if (tempMediaRecorder != null)
                 tempMediaRecorder.deleteOutputFile();


### PR DESCRIPTION
IllegalStateException is thrown on some Android devices, leading to a crash of the plugin and thus the app.